### PR TITLE
fix: ExternalSecret API 버전 v1beta1 → v1 수정

### DIFF
--- a/v3-kubernetes/k8s/base/external-secrets/backend-es.yaml
+++ b/v3-kubernetes/k8s/base/external-secrets/backend-es.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: backend-secret

--- a/v3-kubernetes/k8s/base/external-secrets/recommend-es.yaml
+++ b/v3-kubernetes/k8s/base/external-secrets/recommend-es.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: recommend-secret

--- a/v3-kubernetes/k8s/base/external-secrets/secret-store.yaml
+++ b/v3-kubernetes/k8s/base/external-secrets/secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: aws-ssm


### PR DESCRIPTION
## 개요

ESO v2.1.0은 v1 API만 지원하여 ArgoCD sync 실패 발생

## 변경 사항

-
-
-

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: #123) -->
- closes #

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따르고 있나요?
- [ ] PR 제목이 커밋 컨벤션을 따르고 있나요? (예: `feat: 기능 설명`)
- [ ] 테스트를 수행했나요?
- [ ] 문서 업데이트가 필요한가요?

## 스크린샷 (선택)

<!-- 변경 사항을 시각적으로 보여줄 수 있다면 추가해주세요 -->

## 추가 정보 (선택)

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
