### PR TITLE
feat: Grafana, Traefik, Swagger를 Tailscale tailnet으로 사설 노출

### DIFF
--- a/v3-kubernetes/k8s/argocd-prod/monitoring.yaml
+++ b/v3-kubernetes/k8s/argocd-prod/monitoring.yaml
@@ -17,6 +17,10 @@ spec:
             existingSecret: monitoring-secrets # pragma: allowlist secret
             userKey: GRAFANA_ADMIN_USER # pragma: allowlist secret
             passwordKey: GRAFANA_ADMIN_PASSWORD # pragma: allowlist secret
+          service:
+            annotations:
+              tailscale.com/expose: "true"
+              tailscale.com/hostname: "grafana"
           resources:
             requests:
               cpu: 100m

--- a/v3-kubernetes/k8s/argocd-prod/traefik.yaml
+++ b/v3-kubernetes/k8s/argocd-prod/traefik.yaml
@@ -15,6 +15,9 @@ spec:
           kind: DaemonSet
         service:
           type: NodePort
+          annotations:
+            tailscale.com/expose: "true"
+            tailscale.com/hostname: "traefik"
         ports:
           web:
             port: 8000

--- a/v3-kubernetes/k8s/overlays/prod/backend/kustomization.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/backend/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 patches:
   - path: patches/resources.yaml
   - path: patches/external-secret.yaml
+  - path: patches/service.yaml
 
 images:
   - name: moyeobab/backend

--- a/v3-kubernetes/k8s/overlays/prod/backend/patches/service.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/backend/patches/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "swagger"


### PR DESCRIPTION
## 개요

Grafana, Traefik Dashboard, Swagger를 Tailscale tailnet으로 사설 노출하여 SSM port-forward 없이 운영 UI에 접근할 수 있도록 구성.

## 변경 사항

- Grafana Service에 Tailscale annotation 추가 (monitoring.yaml)
- Traefik Service에 Tailscale annotation 추가 (traefik.yaml)
- Swagger(backend) Service를 prod overlay에서만 Tailscale 노출 (patches/service.yaml)

## 관련 이슈

- closes #281

## 체크리스트

- [x] 커밋 메시지가 컨벤션을 따르고 있나요?
- [x] PR 제목이 커밋 컨벤션을 따르고 있나요? (예: `feat: 기능 설명`)
- [ ] 테스트를 수행했나요?
- [ ] 문서 업데이트가 필요한가요?

## 추가 정보 (선택)

- ArgoCD는 자기 자신을 관리할 수 없어 수동 patch 필요: `kubectl patch svc argocd-server -n argocd --type=merge
-p='{"metadata":{"annotations":{"tailscale.com/expose":"true","tailscale.com/hostname":"argocd"}}}'`
- 현재 TLS 미적용 상태 (http), Tailscale WireGuard 암호화로 통신 자체는 안전
- 후속 작업: TLS annotation 추가 (`tailscale.com/tls: "true"`) → HTTPS 전환

---
Refs #3