### PR TITLE
feat: Loki + Alloy 로그 수집 스택 및 Grafana Loki 데이터소스 추가

### DIFF
--- a/v3-kubernetes/k8s/argocd-prod/alloy.yaml
+++ b/v3-kubernetes/k8s/argocd-prod/alloy.yaml
@@ -1,0 +1,71 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alloy
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: alloy
+    targetRevision: "*"
+    helm:
+      valuesObject:
+        alloy:
+          configMap:
+            content: |
+              // K8s Pod 로그 수집
+              discovery.kubernetes "pods" {
+                role = "pod"
+              }
+
+              discovery.relabel "pods" {
+                targets = discovery.kubernetes.pods.targets
+
+                rule {
+                  source_labels = ["__meta_kubernetes_namespace"]
+                  target_label  = "namespace"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_name"]
+                  target_label  = "pod"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_container_name"]
+                  target_label  = "container"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_label_app"]
+                  target_label  = "app"
+                }
+              }
+
+              loki.source.kubernetes "pods" {
+                targets    = discovery.relabel.pods.output
+                forward_to = [loki.write.default.receiver]
+              }
+
+              loki.write "default" {
+                endpoint {
+                  url = "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+                }
+              }
+        controller:
+          type: daemonset
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/v3-kubernetes/k8s/argocd-prod/loki.yaml
+++ b/v3-kubernetes/k8s/argocd-prod/loki.yaml
@@ -1,0 +1,67 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: loki
+    targetRevision: "*"
+    helm:
+      valuesObject:
+        deploymentMode: SingleBinary
+        loki:
+          auth_enabled: false
+          commonConfig:
+            replication_factor: 1
+          storage:
+            type: filesystem
+          schemaConfig:
+            configs:
+              - from: "2024-01-01"
+                store: tsdb
+                object_store: filesystem
+                schema: v13
+                index:
+                  prefix: index_
+                  period: 24h
+          limits_config:
+            retention_period: 15d
+        singleBinary:
+          replicas: 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+          persistence:
+            enabled: true
+            storageClass: ebs-gp3
+            size: 30Gi
+        # SingleBinary 모드 — 불필요한 컴포넌트 비활성화
+        read:
+          replicas: 0
+        write:
+          replicas: 0
+        backend:
+          replicas: 0
+        gateway:
+          enabled: false
+        chunksCache:
+          enabled: false
+        resultsCache:
+          enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/v3-kubernetes/k8s/argocd-prod/monitoring.yaml
+++ b/v3-kubernetes/k8s/argocd-prod/monitoring.yaml
@@ -21,6 +21,12 @@ spec:
             annotations:
               tailscale.com/expose: "true"
               tailscale.com/hostname: "grafana"
+          additionalDataSources:
+            - name: Loki
+              type: loki
+              url: http://loki.monitoring.svc.cluster.local:3100
+              access: proxy
+              isDefault: false
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## 개요

Loki + Alloy로 K8s 클러스터 내부 Pod 로그 수집 스택 구성 및 Grafana Loki 데이터소스 자동 프로비저닝.

## 변경 사항

- Loki SingleBinary 모드 ArgoCD Application 추가 (EBS 30Gi 영구 스토리지, retention 15일)
- Alloy DaemonSet ArgoCD Application 추가 (모든 노드에서 Pod 로그 수집 → Loki push)
- Grafana에 Loki 데이터소스 자동 추가 (additionalDataSources)

## 관련 이슈

- closes #280

## 체크리스트

- [x] 커밋 메시지가 컨벤션을 따르고 있나요?
- [x] PR 제목이 커밋 컨벤션을 따르고 있나요?
- [ ] 테스트를 수행했나요?
- [ ] 문서 업데이트가 필요한가요?

## 추가 정보 (선택)

- Loki: SingleBinary 모드, gateway/cache 비활성화, monitoring 네임스페이스 배포
- Alloy: K8s Pod 로그를 namespace/pod/container/app 라벨로 수집
- EC2 로그(Redis, PostgreSQL 등)는 기존 Promtail 유지, 후속 작업으로 Loki URL 전환 예정

---
Refs #3