### PR TITLE
fix: AlertManager webhook_url_file을 tplConfig + readFile 방식으로 변경

### DIFF
--- a/v3-kubernetes/k8s/argocd-prod/monitoring.yaml
+++ b/v3-kubernetes/k8s/argocd-prod/monitoring.yaml
@@ -156,6 +156,7 @@ spec:
                 memory: 128Mi
             # ExternalSecret으로 생성된 Secret을 Pod에 마운트
             secrets: ['monitoring-secrets']
+          tplConfig: true
           config:
             global:
               resolve_timeout: 5m
@@ -176,13 +177,13 @@ spec:
               - name: 'null'
               - name: 'critical'
                 discord_configs:
-                  - webhook_url_file: '/etc/alertmanager/secrets/monitoring-secrets/DISCORD_WEBHOOK_CRITICAL' # pragma: allowlist secret
+                  - webhook_url: '{{ readFile "/etc/alertmanager/secrets/monitoring-secrets/DISCORD_WEBHOOK_CRITICAL" }}' # pragma: allowlist secret
                     send_resolved: true
                     title: '{{ if eq .Status "firing" }}🚨 [CRITICAL] {{ else }}✅ [RESOLVED] {{ end }}{{ .GroupLabels.alertname }}'
                     content: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}{{ end }}"
               - name: 'warning'
                 discord_configs:
-                  - webhook_url_file: '/etc/alertmanager/secrets/monitoring-secrets/DISCORD_WEBHOOK_WARNING' # pragma: allowlist secret
+                  - webhook_url: '{{ readFile "/etc/alertmanager/secrets/monitoring-secrets/DISCORD_WEBHOOK_WARNING" }}' # pragma: allowlist secret
                     send_resolved: true
                     title: '{{ if eq .Status "firing" }}⚠️ [WARNING] {{ else }}✅ [RESOLVED] {{ end }}{{ .GroupLabels.alertname }}'
                     content: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}{{ end }}"


### PR DESCRIPTION
## 개요

Prometheus Operator가 discord_configs의 webhook_url_file을 미지원하여 AlertManager reconcile 실패 수정.

## 변경 사항

- `webhook_url_file` → `webhook_url` + `readFile` Go template으로 변경
- `tplConfig: true` 활성화하여 AlertManager config에서 Go template 사용 가능하도록 설정

## 관련 이슈

- closes #280

## 체크리스트

- [x] 커밋 메시지가 컨벤션을 따르고 있나요?
- [x] PR 제목이 커밋 컨벤션을 따르고 있나요?
- [ ] 테스트를 수행했나요?
- [ ] 문서 업데이트가 필요한가요?

## 추가 정보 (선택)

- Discord webhook URL은 여전히 SSM → ExternalSecret → Secret → 파일 마운트로 관리 (Git 미노출)
- `readFile`이 마운트된 Secret 파일 내용을 읽어 `webhook_url` 값으로 주입
- `webhook_url_file`은 AlertManager v0.27+ 기능이나, 현재 Prometheus Operator CRD가 미지원

---
Refs #3