### PR TITLE
fix: ServiceMonitor를 base에서 prod overlay로 이동하여 dev 배포 실패 해결

### DIFF
--- a/v3-kubernetes/k8s/base/backend/kustomization.yaml
+++ b/v3-kubernetes/k8s/base/backend/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
   - service.yaml
   - external-secret.yaml
   - httproute.yaml
-  - servicemonitor.yaml

--- a/v3-kubernetes/k8s/base/backend/service.yaml
+++ b/v3-kubernetes/k8s/base/backend/service.yaml
@@ -6,5 +6,6 @@ spec:
   selector:
     app: backend
   ports:
-    - port: 8080
+    - name: http
+      port: 8080
       targetPort: 8080

--- a/v3-kubernetes/k8s/base/chatbot/kustomization.yaml
+++ b/v3-kubernetes/k8s/base/chatbot/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - deployment.yaml
   - service.yaml
   - external-secret.yaml
-  - servicemonitor.yaml

--- a/v3-kubernetes/k8s/base/chatbot/service.yaml
+++ b/v3-kubernetes/k8s/base/chatbot/service.yaml
@@ -6,5 +6,6 @@ spec:
   selector:
     app: chatbot
   ports:
-    - port: 8000
+    - name: http
+      port: 8000
       targetPort: 8000

--- a/v3-kubernetes/k8s/base/recommend/kustomization.yaml
+++ b/v3-kubernetes/k8s/base/recommend/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - deployment.yaml
   - service.yaml
   - external-secret.yaml
-  - servicemonitor.yaml

--- a/v3-kubernetes/k8s/base/recommend/service.yaml
+++ b/v3-kubernetes/k8s/base/recommend/service.yaml
@@ -6,5 +6,6 @@ spec:
   selector:
     app: recommend
   ports:
-    - port: 8000
+    - name: http
+      port: 8000
       targetPort: 8000

--- a/v3-kubernetes/k8s/overlays/prod/backend/kustomization.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/backend/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../base/backend
+  - servicemonitor.yaml
 
 patches:
   - path: patches/resources.yaml

--- a/v3-kubernetes/k8s/overlays/prod/backend/servicemonitor.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/backend/servicemonitor.yaml
@@ -7,6 +7,6 @@ spec:
     matchLabels:
       app: backend
   endpoints:
-    - port: "8080"
+    - port: http
       path: /actuator/prometheus
       interval: 15s

--- a/v3-kubernetes/k8s/overlays/prod/chatbot/kustomization.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/chatbot/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../base/chatbot
+  - servicemonitor.yaml
 
 patches:
   - path: patches/resources.yaml

--- a/v3-kubernetes/k8s/overlays/prod/chatbot/servicemonitor.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/chatbot/servicemonitor.yaml
@@ -1,12 +1,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: recommend
+  name: chatbot
 spec:
   selector:
     matchLabels:
-      app: recommend
+      app: chatbot
   endpoints:
-    - port: "8000"
+    - port: http
       path: /metrics
       interval: 15s

--- a/v3-kubernetes/k8s/overlays/prod/recommend/kustomization.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/recommend/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../base/recommend
+  - servicemonitor.yaml
 
 patches:
   - path: patches/resources.yaml

--- a/v3-kubernetes/k8s/overlays/prod/recommend/servicemonitor.yaml
+++ b/v3-kubernetes/k8s/overlays/prod/recommend/servicemonitor.yaml
@@ -1,12 +1,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: chatbot
+  name: recommend
 spec:
   selector:
     matchLabels:
-      app: chatbot
+      app: recommend
   endpoints:
-    - port: "8000"
+    - port: http
       path: /metrics
       interval: 15s


### PR DESCRIPTION
dev 클러스터에 Prometheus Operator CRD가 없어 ServiceMonitor 리소스 sync 실패. base에서 제거하고 prod overlay로 이동. Service 포트에 name 추가.

---
Refs #3